### PR TITLE
fix: replace removed getv() API for IDA Pro 9.3 compatibility

### DIFF
--- a/ida_happy/modules/argument_labeler/edit.py
+++ b/ida_happy/modules/argument_labeler/edit.py
@@ -71,7 +71,7 @@ class HexraysLabelEditHook(ida_hexrays.Hexrays_Hooks):
                 error('Unexpected function call')
                 return HandleStatus.NOT_HANDLED
 
-            tif = fcall.x.v.getv().tif
+            tif = fcall.x.type
         else:
             # NOTE: when working with large IDBs,
             # we often can't get type information without decompiling functions first.

--- a/ida_happy/modules/argument_labeler/edit.py
+++ b/ida_happy/modules/argument_labeler/edit.py
@@ -71,7 +71,7 @@ class HexraysLabelEditHook(ida_hexrays.Hexrays_Hooks):
                 error('Unexpected function call')
                 return HandleStatus.NOT_HANDLED
 
-            tif = fcall.x.type
+            tif = fcall.x.v.mba.vars[fcall.x.v.idx].tif
         else:
             # NOTE: when working with large IDBs,
             # we often can't get type information without decompiling functions first.

--- a/ida_happy/modules/argument_labeler/label.py
+++ b/ida_happy/modules/argument_labeler/label.py
@@ -84,7 +84,7 @@ class HexraysParamLabelHook(ida_hexrays.Hexrays_Hooks):
             if fcall.x.op != idaapi.cot_var:
                 return None
 
-            tif = fcall.x.type
+            tif = fcall.x.v.mba.vars[fcall.x.v.idx].tif
         else:
             tif = ida_typeinf.tinfo_t()
             if not idaapi.get_tinfo(tif, func_ea):

--- a/ida_happy/modules/argument_labeler/label.py
+++ b/ida_happy/modules/argument_labeler/label.py
@@ -84,7 +84,7 @@ class HexraysParamLabelHook(ida_hexrays.Hexrays_Hooks):
             if fcall.x.op != idaapi.cot_var:
                 return None
 
-            tif = fcall.x.v.getv().tif
+            tif = fcall.x.type
         else:
             tif = ida_typeinf.tinfo_t()
             if not idaapi.get_tinfo(tif, func_ea):

--- a/ida_happy/modules/argument_labeler/sync_name.py
+++ b/ida_happy/modules/argument_labeler/sync_name.py
@@ -48,7 +48,7 @@ class HexraysLabelNameSyncHook(ida_hexrays.Hexrays_Hooks):
                 error('Unexpected function call')
                 return HandleStatus.HANDLED
 
-            tif = fcall.x.v.getv().tif
+            tif = fcall.x.type
         else:
             # NOTE: when working with large IDBs,
             # we often can't get type information without decompiling functions first.
@@ -73,7 +73,7 @@ class HexraysLabelNameSyncHook(ida_hexrays.Hexrays_Hooks):
             error('Failed to retrieve function details.')
             return HandleStatus.HANDLED
 
-        lvar = item.e.v.getv()
+        lvar = vdui.cfunc.lvars[item.e.v.idx]
         sel_name, success = ida_kernwin.get_highlight(vdui.ct)
         if not success:
             error('Failed to retrieve highlighted variable name')

--- a/ida_happy/modules/argument_labeler/sync_name.py
+++ b/ida_happy/modules/argument_labeler/sync_name.py
@@ -48,7 +48,7 @@ class HexraysLabelNameSyncHook(ida_hexrays.Hexrays_Hooks):
                 error('Unexpected function call')
                 return HandleStatus.HANDLED
 
-            tif = fcall.x.type
+            tif = fcall.x.v.mba.vars[fcall.x.v.idx].tif
         else:
             # NOTE: when working with large IDBs,
             # we often can't get type information without decompiling functions first.

--- a/ida_happy/modules/argument_labeler/sync_type.py
+++ b/ida_happy/modules/argument_labeler/sync_type.py
@@ -40,7 +40,7 @@ class HexraysLabelTypeSyncHook(ida_hexrays.Hexrays_Hooks):
         if (e.op == ida_hexrays.cot_cast and
             e.x and e.x.op == ida_hexrays.cot_var):
             func = idaapi.get_func(idaapi.get_screen_ea())
-            lvar = e.x.v.getv()
+            lvar = vdui.cfunc.lvars[e.x.v.idx]
 
             self.retype_pseudocode_var(func.start_ea, lvar.name, e.type)
             vdui.refresh_view(True)
@@ -58,7 +58,7 @@ class HexraysLabelTypeSyncHook(ida_hexrays.Hexrays_Hooks):
 
             to_byte = lambda n: n // 8
             cast_type = e.type.get_pointed_object()
-            lvar = e.x.x.x.x.v.getv()
+            lvar = vdui.cfunc.lvars[e.x.x.x.x.v.idx]
             tif = lvar.type().get_pointed_object()
             udm = self.get_member(tif, e.x.x.x.m)
             if not udm:


### PR DESCRIPTION
Hex-Rays somehow removed `getv()` from `var_ref_t` in 9.3 SDK:
https://github.com/HexRaysSA/ida-sdk/blob/acef1e391fab434451e6c1b9f04848a59f69e8d8/src/plugins/idapython/swig/hexrays.i#L360

This PR fix it with equivalent APIs:
  - `fcall.x.v.getv().tif` → `fcall.x.type` (use type from `cot_var` directly)
  - `expr.v.getv()` → `vdui.cfunc.lvars[expr.v.idx]`